### PR TITLE
9: Add OG sizing metatags for FB images.

### DIFF
--- a/modules/cm_bootstrap_metatag/cm_bootstrap_metatag.module
+++ b/modules/cm_bootstrap_metatag/cm_bootstrap_metatag.module
@@ -4,6 +4,9 @@ function cm_bootstrap_metatag_metatag_metatags_view_alter(&$output, $instance) {
   switch ($instance) {
     case 'node:page':
     case 'node:blog':
+      module_load_include('inc', 'cm_bootstrap_metatag', 'inc/og_image');
+      cm_bootstrap_metatag_page_image();
+
       if (empty($output['description']) && empty($output['og:description'])) {
         module_load_include('inc', 'cm_bootstrap_metatag', 'inc/description');
         cm_bootstrap_metatag_description();

--- a/modules/cm_bootstrap_metatag/inc/og_image.inc
+++ b/modules/cm_bootstrap_metatag/inc/og_image.inc
@@ -45,5 +45,30 @@ function cm_bootstrap_metatag_page_image() {
     );
     drupal_add_html_head($og_image, 'og:image');
 
+    // Get image data.
+    $img_data = image_get_info($img_src);
+
+    // If possible, add image sizing tags.
+    if ($img_data !== FALSE) {
+      $og_image_width = array(
+        '#type' => 'html_tag',
+        '#tag' => 'meta',
+        '#attributes' => array(
+          'property' => 'og:image:width',
+          'content' => $img_data['width'],
+        ),
+      );
+      drupal_add_html_head($og_image_width, 'og:image:width');
+
+      $og_image_height = array(
+        '#type' => 'html_tag',
+        '#tag' => 'meta',
+        '#attributes' => array(
+          'property' => 'og:image:height',
+          'content' => $img_data['height'],
+        ),
+      );
+      drupal_add_html_head($og_image_height, 'og:image:height');
+    }
   }
 }


### PR DESCRIPTION
This adds sizing OG image tags, in order to properly inform Facebook about the default image.

Testing multisite: http://43-fb-cm-bootstrap.pantheonsite.io/show/uvm-lane-series-natalie-neuert-0