### PR TITLE
Z-69: Move the underline to the description.

### DIFF
--- a/modules/content_components/modules/cc_content_list/css/cc_content_list.css
+++ b/modules/content_components/modules/cc_content_list/css/cc_content_list.css
@@ -14,21 +14,24 @@
   /* line 8, ../scss/cc_content_list.scss */
   .cc--cl h2 {
     text-transform: uppercase;
-    border-bottom: 1px solid gainsboro;
-    padding: 0 0 .5em 0;
-    margin-bottom: 1.5em;
   }
-  /* line 14, ../scss/cc_content_list.scss */
+  /* line 11, ../scss/cc_content_list.scss */
+  .cc--cl .col-md-12 {
+    border-bottom: 1px solid gainsboro;
+    margin-bottom: 1.5em;
+    padding-bottom: 1em;
+  }
+  /* line 16, ../scss/cc_content_list.scss */
   .cc--cl .clean-ul-list {
     list-style-type: none;
     padding: 0;
   }
-  /* line 23, ../scss/cc_content_list.scss */
+  /* line 25, ../scss/cc_content_list.scss */
   .cc--cl ul.cl-items li {
     margin-bottom: 1em;
   }
 
-  /* line 32, ../scss/cc_content_list.scss */
+  /* line 34, ../scss/cc_content_list.scss */
   .cc-cl--title-display-overlay .overlay-wrapper a,
   .cc-cl--title-display-overlay .overlay-wrapper .no-link {
     display: block;
@@ -40,7 +43,7 @@
     overflow: hidden;
     position: relative;
   }
-  /* line 43, ../scss/cc_content_list.scss */
+  /* line 45, ../scss/cc_content_list.scss */
   .cc-cl--title-display-overlay .overlay-wrapper .overlay {
     position: absolute;
     background: rgba(0, 0, 0, 0.25);
@@ -48,19 +51,19 @@
     width: 100%;
     height: 100%;
   }
-  /* line 49, ../scss/cc_content_list.scss */
+  /* line 51, ../scss/cc_content_list.scss */
   .cc-cl--title-display-overlay .overlay-wrapper .overlay h3 {
     color: white;
     position: absolute;
     bottom: 0;
     padding: 0 .5em;
   }
-  /* line 56, ../scss/cc_content_list.scss */
+  /* line 58, ../scss/cc_content_list.scss */
   .cc-cl--title-display-overlay .overlay-wrapper a:hover .overlay,
   .cc-cl--title-display-overlay .overlay-wrapper .no-link:hover .overlay {
     background: rgba(0, 0, 0, 0.5);
   }
-  /* line 60, ../scss/cc_content_list.scss */
+  /* line 62, ../scss/cc_content_list.scss */
   .cc-cl--title-display-overlay .overlay-wrapper p {
     padding: 1em 0;
   }

--- a/modules/content_components/modules/cc_content_list/scss/cc_content_list.scss
+++ b/modules/content_components/modules/cc_content_list/scss/cc_content_list.scss
@@ -7,9 +7,11 @@
     }
     h2 {
       text-transform: uppercase;
+    }
+    .col-md-12 {
       border-bottom: 1px solid gainsboro;
-      padding: 0 0 .5em 0;
       margin-bottom: 1.5em;
+      padding-bottom: 1em;
     }
     .clean-ul-list {
       list-style-type: none;


### PR DESCRIPTION
This moves the underline to below the description, so that the descriptive text doesn't look "orphaned".