### PR TITLE
ZD-295: Add telvue connect support to series and partner pages.

### DIFF
--- a/themes/cmb_theme/templates/node/node--cm_project.tpl.php
+++ b/themes/cmb_theme/templates/node/node--cm_project.tpl.php
@@ -44,6 +44,17 @@
           $iframe_src = 'http://vp.telvue.com/player?wmode=opaque&modestbranding=1
 &HTML5=true&id=' . $iframe_src_param_id . '&video=' . $iframe_src_param_video . '&noplaylistskin=1&width=400&height=300';
           break;
+        case 'video/connect':
+          $iframe_class = 'media-telvue-player';
+          // Get param 'video'.
+          $iframe_src_param_video = $cm_show_node->field_show_vod['und'][0]['filename'];
+          // Get param 'id'.
+          $uri = $cm_show_node->field_show_vod['und'][0]['uri'];
+          $string_pieces = explode('/', $uri);
+          $iframe_src_param_id = $string_pieces[3];
+          // Build iframe src.
+          $iframe_src = 'https://videoplayer.telvue.com/player/' .  $iframe_src_param_id . '/media/' . $iframe_src_param_video . '?fullscreen=true&amp;autostart=false';
+          break;
         case 'video/vimeo':
           $video_container_class = 'video-container-vimeo';
           $iframe_class = 'media-vimeo-player';

--- a/themes/cmb_theme/templates/node/node--partner.tpl.php
+++ b/themes/cmb_theme/templates/node/node--partner.tpl.php
@@ -114,6 +114,17 @@ if (isset($feature_video->field_show_vod['und'])) {
       // Build iframe src.
       $iframe_src = 'http://vp.telvue.com/player?wmode=opaque&amp;id=' . $iframe_src_param_id . '&amp;video=' . $iframe_src_param_video . '&amp;noplaylistskin=1&amp;width=400&amp;height=300';
       break;
+    case 'video/connect':
+      $iframe_class = 'media-telvue-player';
+      // Get param 'video'.
+      $iframe_src_param_video = $feature_video->field_show_vod['und'][0]['filename'];
+      // Get param 'id'.
+      $uri = $feature_video->field_show_vod['und'][0]['uri'];
+      $string_pieces = explode('/', $uri);
+      $iframe_src_param_id = $string_pieces[3];
+      // Build iframe src.
+      $iframe_src = 'https://videoplayer.telvue.com/player/' .  $iframe_src_param_id . '/media/' . $iframe_src_param_video . '?fullscreen=true&amp;autostart=false';
+      break;
     case 'video/vimeo':
       $iframe_class = 'media-vimeo-player';
       // Get param 'video'.


### PR DESCRIPTION
Adds support for the telvue connect (i.e. mimetype = video/connect) iframe to the series and partner pages.

Note that if these pages are later switched to use paragraphs instead, this code will not be required. It is a useful temporary stop-gap to assist with issues that a number of sites are seeing.